### PR TITLE
Flux derivative tally scoring

### DIFF
--- a/src/qmc_source_iteration.jl
+++ b/src/qmc_source_iteration.jl
@@ -53,10 +53,10 @@ function qmc_source_iteration(s, qmc_data, tol=1.e-8)
     phi_avg_old = zeros(Nx)
     reshist = []
     #globalize variables
-    phi_edge = J_avg = J_edge = exit_right_bins = exit_left_bins = 0
+    phi_edge = dphi =  J_avg = J_edge = exit_right_bins = exit_left_bins = 0
 
     while itt < 200 && delflux > tol
-        phi_avg, phi_edge, J_avg, J_edge, exit_right_bins, exit_left_bins = qmc_sweep(phi_avg,qmc_data)
+        phi_avg, phi_edge, dphi, J_avg, J_edge, exit_right_bins, exit_left_bins = qmc_sweep(phi_avg,qmc_data)
         delflux = norm(phi_avg - phi_avg_old, Inf)
         itt += 1
         push!(reshist, delflux)
@@ -67,6 +67,7 @@ function qmc_source_iteration(s, qmc_data, tol=1.e-8)
 
     return (phi_avg = phi_avg,
             phi_edge = phi_edge,
+            dphi = dphi,
             J_avg = J_avg,
             J_edge = J_edge,
             psi_right = exit_right_bins,

--- a/src/qmc_test.jl
+++ b/src/qmc_test.jl
@@ -17,7 +17,7 @@ s = 1 #parameter in Garcia/Siewert
 # initialize qmc
 qmc_data = qmc_init(N, Nx, na2, s)
 # call qmc SI
-phi_avg, phi_edge, J_avg, J_edge, psi_right, psi_left, history, itt = qmc_source_iteration(s,qmc_data)
+phi_avg, phi_edge, dphi, J_avg, J_edge, psi_right, psi_left, history, itt = qmc_source_iteration(s,qmc_data)
 
 
 ###############################################################################
@@ -40,15 +40,15 @@ title("Cell Averaged Scalar Flux")
 
 # cell Averaged Spatial Derivative of Scalar Flux
 subplot(312)
-plot(edges,phi_edge)
-ylabel("phi edges")
-xlabel("cell edges")
-title("Cell edge Scalar Flux")
+plot(midpoints,dphi)
+ylabel("dphi")
+xlabel("cell midpoints")
+title("Cell Flux Derivative")
 
 # cell averaged current
 subplot(313)
 plot(midpoints,J_avg)
-ylabel("current")
+ylabel("J avg")
 xlabel("midpoints")
 title("Cell Averaged Current")
 


### PR DESCRIPTION
- Added flux derivative tally scoring (dphi)
- dphi is now an output of qmc_source_iteration() and plotted in qmc_test.jl

![Screen Shot 2021-04-01 at 2 46 43 PM](https://user-images.githubusercontent.com/46267220/113339892-26c6b200-92f9-11eb-9ade-17b72879fa93.png)
